### PR TITLE
Feature 시나리오 리스트 요청

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,17 @@
+import ScenarioItem from '@/components/shared/ScenarioItem';
 import { getScenarioList } from '@/remotes/server/scenario';
 
 export default async function Home() {
   const scenarioList = await getScenarioList();
-  console.log(scenarioList);
+
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-24">
+    <main>
       <h1>Main</h1>
+      <div className="flex flex-col justify-between gap-5">
+        {scenarioList.map(item => (
+          <ScenarioItem key={item._id} scenario={item} />
+        ))}
+      </div>
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,8 @@
-export default function Home() {
+import { getScenarioList } from '@/remotes/server/scenario';
+
+export default async function Home() {
+  const scenarioList = await getScenarioList();
+  console.log(scenarioList);
   return (
     <main className="flex min-h-screen flex-col items-center justify-between p-24">
       <h1>Main</h1>

--- a/src/components/shared/ScenarioItem.tsx
+++ b/src/components/shared/ScenarioItem.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link';
+// type
+import { ScenarioType } from '@/models';
+
+interface ScenarioItemProps {
+  scenario: ScenarioType;
+}
+export default function ScenarioItem({ scenario }: ScenarioItemProps) {
+  return (
+    <div className="max-w-2xl px-8 py-4 bg-white rounded-lg shadow-md dark:bg-gray-800">
+      <div className="mt-2">
+        <Link
+          href="#"
+          className="text-xl font-bold text-gray-700 dark:text-white hover:text-gray-600 dark:hover:text-gray-200 hover:underline"
+        >
+          {scenario.title}
+        </Link>
+        <p className="mt-2 text-gray-600 dark:text-gray-300 line-clamp-3">{scenario.prologue}</p>
+      </div>
+
+      <div className="flex items-center justify-between mt-4">
+        <div className="flex gap-3">
+          <Link
+            href="#"
+            className="px-3 py-1 text-sm font-bold text-gray-100 transition-colors duration-300 transform bg-gray-600 rounded cursor-pointer hover:bg-gray-500"
+          >
+            {scenario.genre}
+          </Link>
+          <Link
+            href="#"
+            className="px-3 py-1 text-sm font-bold text-gray-100 transition-colors duration-300 transform bg-gray-600 rounded cursor-pointer hover:bg-gray-500"
+          >
+            {scenario.background}
+          </Link>
+        </div>
+
+        <div className="flex items-center">
+          <p className="font-bold text-gray-700 cursor-pointer dark:text-gray-200">고나우</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/remotes/schema/index.ts
+++ b/src/remotes/schema/index.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 // 시나리오 스키마
 export const ScenarioSchema = z.object({
+  _id: z.string().optional(),
   title: z.string().min(1, { message: '제목을 작성해주세요.' }),
   genre: z.string().min(1, { message: '장르를 선택해주세요.' }),
   background: z.string().min(1, { message: '세계관을 선택해주세요.' }),

--- a/src/remotes/schema/index.ts
+++ b/src/remotes/schema/index.ts
@@ -8,3 +8,6 @@ export const ScenarioSchema = z.object({
   prologue: z.string().min(1),
   description: z.string().min(1, { message: '설명을 작성해주세요.' }),
 });
+
+// 시나리오 리스트 스키마
+export const ScenarioListSchema = z.array(ScenarioSchema);

--- a/src/remotes/server/scenario.ts
+++ b/src/remotes/server/scenario.ts
@@ -1,0 +1,13 @@
+import { connectDB } from '../mongodb';
+// type & schema
+import { ScenarioType } from '@/models';
+import { ScenarioListSchema } from '../schema';
+
+// 시나리오 리스트 가져오기
+export const getScenarioList = async (): Promise<ScenarioType[]> => {
+  const db = (await connectDB).db('prototype');
+  const response = await db.collection('scenario').find().toArray();
+  const scenarioList = ScenarioListSchema.parse(response.map(item => ({ ...item, _id: item._id.toString() })));
+  console.log('시나리오 리스트 fetching 실행됨!');
+  return scenarioList;
+};


### PR DESCRIPTION
### 개요
시나리오 리스트 요청 구현

### 주요 사항
> 요청 API 구현
- 서버 측에서 사용할 시나리오 리스트 요청 함수
- mongoDB connect를 사용하고 서버컴포넌트에서 사용됨
- 시나리오 리스트 zod 스키마 생성(배열)
- zod 스키마의 parse를 통해 데이터 타입 검증

<br/>

> 시나리오 아이템 컴포넌트 생성
- 시나리오 데이터를 렌더링할 ScenarioItem 컴포넌트 생성
- props로 ScenarioType을 받음(나중에 재사용이 가능할것 같음)
- 시나리오의 글자수가 넘칠것을 대비해 line-clamp 스타일 적용

<br/>